### PR TITLE
[FEATURE] Clone template28 template into HTML  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .DS_Store
+.venv/
 __pycache__
 static/images/profile_pictures/
 static/rendered/

--- a/static/resume_templates/css/template28.css
+++ b/static/resume_templates/css/template28.css
@@ -8,7 +8,7 @@ body {
 .header {
     background: #4d4d4d;
     font-size: 50px;
-    padding: 5px;
+    padding: 10px;
     font-weight: 100;
     font-family: 'Roboto', sans-serif;
 }

--- a/static/resume_templates/css/template28.css
+++ b/static/resume_templates/css/template28.css
@@ -1,0 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@700&family=Roboto:wght@100;500&display=swap');
+
+body {
+    font-weight: 200 !important;
+    background: #787a7d !important;
+}
+
+.header {
+    background: #4d4d4d;
+    font-size: 50px;
+    padding: 5px;
+    font-weight: 100;
+    font-family: 'Roboto', sans-serif;
+}
+
+.header-font {
+    font-family: 'Roboto Condensed', sans-serif;
+}

--- a/static/resume_templates/html/template28.html
+++ b/static/resume_templates/html/template28.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Template 28</title>
+    <link rel="stylesheet" href="../css/template28.css">
+    <link rel="stylesheet" href="../../css/bootstrap.min.css">
+</head>
+
+<body>
+    <div class="container">
+        <div class="shadow-lg bg-white">
+
+            <div class="header text-white text-center">
+                França<b>Caroline</b>
+            </div>
+
+            <div class="row mt-2 p-5">
+                <div class="col-md-3">
+
+                    <div class="profile-image text-center">
+                        <img src="../../images/profile_pictures/1/1.jpg" alt="Franca" height="150">
+                    </div>
+                    <br>
+
+                    <div class="contact">
+                        <h4 class="header-font">Contact</h4>
+                        <p> Av. Antônio de Carvalho,
+                            1584 - Jd. Carvalho.
+                            RS - Porto Alegre, Brazil.</p>
+                        <p>(+555)51-98482-5495</p>
+                        <p>carolfranca90@gmail.com</p>
+                    </div>
+
+                    <div class="languages">
+                        <h4 class="header-font">Languages</h4>
+                        English- advanced <br>
+                        Portuguese- native
+                        <p></p>
+                    </div>
+
+                    <div class="interested-profile">
+                        <h4 class="header-font">Interested Profile</h4>
+                        IC Designer <br>
+                        RF IC Designer <br>
+                        Analog IC Designer <br>
+                        Electrical Engineer <br>
+                        Electronics Engineer
+                    </div>
+                </div>
+
+                <div class="col-md-9">
+                    <div class="education mt-5 mt-md-0">
+                        <h3 class="header-font"><span style="color: #71dbef;">Edu</span>cation</h3>
+                        <span class="header-font">Current</span>: Design of integrated circuits - CI Brasil, step II.
+                        <br>
+                        <span class="header-font">Master's Degree</span>: Electrical Engineering - UFPR, concluded in
+                        2016. <br>
+                        <span class="header-font">Undergraduate</span>: Electrical engineering - UFPR, concluded in 2014
+                    </div>
+
+                    <div class="experience mt-3">
+                        <h3 class="header-font"><span style="color: #fb4c8a;">Exp</span>erience</h3>
+                        <div class="content ml-5">
+                            <p>
+                                <div class="header-font">Trainee as Analog IC Designer, CI BRASIL (03/2017 -
+                                    Current):</div>
+                                I have been doing trainning in the CI Brasil program in the analog/RF area.
+                                There I have learned concepts of analog and RF circuits and EDA Tools.
+                            </p>
+                            <p>
+                                <div class="header-font">Internship, Ondas energias e sistemas (2014 - 2014):</div>
+                                I have done internship in the area of electrial systems in low/medium-voltage
+                                network. It was some of my attribuations support in projects, and estimative
+                                of prices of the projects.
+                            </p>
+                            <p>
+                                <div class="header-font">Internship, Microsens (2013 - 2014):</div>
+                                I have done internship in the area of electrical engineering. It was some of
+                                my atribuations tests in electronics equipaments and accomplish technical
+                                specifications of the products.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="research mt-3">
+                        <h3 class="header-font"><span style="color: #fe9e2f;">Res</span>earch</h3>
+                        <div class="content ml-5">
+                            <p>
+                                <div class="header-font">Trainee as Analog IC Designer, CI BRASIL (03/2017 -
+                                    Current):</div>
+                                I have been doing trainning in the CI Brasil program in the analog/RF area.
+                                There I have learned concepts of analog and RF circuits and EDA Tools.
+                            </p>
+                            <p>
+                                <div class="header-font">Internship, Ondas energias e sistemas (2014 - 2014):</div>
+                                I have done internship in the area of electrial systems in low/medium-voltage
+                                network. It was some of my attribuations support in projects, and estimative
+                                of prices of the projects.
+                            </p>
+                            <p>
+                                <div class="header-font">Internship, Microsens (2013 - 2014):</div>
+                                I have done internship in the area of electrical engineering. It was some of
+                                my atribuations tests in electronics equipaments and accomplish technical
+                                specifications of the products.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="skills mt-3">
+                        <h3 class="header-font"><span style="color: #b3e54c;">Ski</span>lls</h3>
+                        <div class="content ml-5 header-font">
+                            Cadence - Virtuoso <br>
+                            Keysight - ADS <br>
+                            Layout of IC's <br>
+                            Matlab - Neural Networks <br>
+                            Languages: C, C++, VerilogA <br>
+                            Autocad <br>
+                            Office <br>
+                        </div>
+                    </div>
+
+                    <div class="activities-and-societies mt-3">
+                        <h3 class="header-font"><span style="color: #965efe;">Act</span>ivities and Societies</h3>
+                        <div class="content ml-5 header-font">
+                            Teaching practice in Master's Degree (15 Hs) <br>
+                            Group of integrated circuits and systems (GICs) <br>
+                            Scientific Research in Bachelor's Degree <br>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</body>
+
+</html>

--- a/static/resume_templates/html/template28.html
+++ b/static/resume_templates/html/template28.html
@@ -14,120 +14,86 @@
         <div class="shadow-lg bg-white">
 
             <div class="header text-white text-center">
-                França<b>Caroline</b>
+                {{firstname}}<b>{{lastname}}</b>
             </div>
 
-            <div class="row mt-2 p-5">
+            <div class="row mt-1 p-5">
                 <div class="col-md-3">
 
                     <div class="profile-image text-center">
-                        <img src="../../images/profile_pictures/1/1.jpg" alt="Franca" height="150">
+                        <img src="{{profile_picture}}" alt="{{firstname}}_{{lastname}}" height="170">
                     </div>
                     <br>
 
                     <div class="contact">
                         <h4 class="header-font">Contact</h4>
-                        <p> Av. Antônio de Carvalho,
-                            1584 - Jd. Carvalho.
-                            RS - Porto Alegre, Brazil.</p>
-                        <p>(+555)51-98482-5495</p>
-                        <p>carolfranca90@gmail.com</p>
+                        <p>{{address_1}}</p>
+                        <p>{{mobile}}</p>
+                        <p>{{email}}</p>
                     </div>
 
                     <div class="languages">
                         <h4 class="header-font">Languages</h4>
-                        English- advanced <br>
-                        Portuguese- native
+                        English - advanced <br>
                         <p></p>
                     </div>
 
                     <div class="interested-profile">
                         <h4 class="header-font">Interested Profile</h4>
-                        IC Designer <br>
-                        RF IC Designer <br>
-                        Analog IC Designer <br>
-                        Electrical Engineer <br>
-                        Electronics Engineer
+                        {% for i in range(hobbies|length) %}
+                        {{hobbies[i]}} <br>
+                        {% endfor %}
                     </div>
                 </div>
 
                 <div class="col-md-9">
                     <div class="education mt-5 mt-md-0">
                         <h3 class="header-font"><span style="color: #71dbef;">Edu</span>cation</h3>
-                        <span class="header-font">Current</span>: Design of integrated circuits - CI Brasil, step II.
-                        <br>
-                        <span class="header-font">Master's Degree</span>: Electrical Engineering - UFPR, concluded in
-                        2016. <br>
-                        <span class="header-font">Undergraduate</span>: Electrical engineering - UFPR, concluded in 2014
+                        {% for i in range(degrees|length) %}
+                        <span class="header-font">{{degrees[i]}}</span>: {{fields_of_study[i]}} -
+                        {{institute_names[i]}} ({{cities[i]}}, {{countries[i]}}), {{end_dates[i]}} <br>
+                        {% endfor %}
                     </div>
 
                     <div class="experience mt-3">
                         <h3 class="header-font"><span style="color: #fb4c8a;">Exp</span>erience</h3>
                         <div class="content ml-5">
+                            {% for i in range(start_dates_exp|length) %}
                             <p>
-                                <div class="header-font">Trainee as Analog IC Designer, CI BRASIL (03/2017 -
-                                    Current):</div>
-                                I have been doing trainning in the CI Brasil program in the analog/RF area.
-                                There I have learned concepts of analog and RF circuits and EDA Tools.
+                                <div class="header-font">{{job_titles[i]}}, {{companies[i]}} ({{start_dates_exp[i]}} -
+                                    {{end_dates_exp[i]}}):</div>
+                                {{description[i]}}
                             </p>
-                            <p>
-                                <div class="header-font">Internship, Ondas energias e sistemas (2014 - 2014):</div>
-                                I have done internship in the area of electrial systems in low/medium-voltage
-                                network. It was some of my attribuations support in projects, and estimative
-                                of prices of the projects.
-                            </p>
-                            <p>
-                                <div class="header-font">Internship, Microsens (2013 - 2014):</div>
-                                I have done internship in the area of electrical engineering. It was some of
-                                my atribuations tests in electronics equipaments and accomplish technical
-                                specifications of the products.
-                            </p>
+                            {% endfor %}
                         </div>
                     </div>
 
                     <div class="research mt-3">
                         <h3 class="header-font"><span style="color: #fe9e2f;">Res</span>earch</h3>
                         <div class="content ml-5">
-                            <p>
-                                <div class="header-font">Trainee as Analog IC Designer, CI BRASIL (03/2017 -
-                                    Current):</div>
-                                I have been doing trainning in the CI Brasil program in the analog/RF area.
-                                There I have learned concepts of analog and RF circuits and EDA Tools.
-                            </p>
-                            <p>
-                                <div class="header-font">Internship, Ondas energias e sistemas (2014 - 2014):</div>
-                                I have done internship in the area of electrial systems in low/medium-voltage
-                                network. It was some of my attribuations support in projects, and estimative
-                                of prices of the projects.
-                            </p>
-                            <p>
-                                <div class="header-font">Internship, Microsens (2013 - 2014):</div>
-                                I have done internship in the area of electrical engineering. It was some of
-                                my atribuations tests in electronics equipaments and accomplish technical
-                                specifications of the products.
-                            </p>
+                            {% for i in range(project_title|length) %}
+                            <div class="header-font">{{project_title[i]}} ({{start_dates_proj[i]}} -
+                                {{end_dates_proj[i]}})</div>
+                            {{description_proj[i]}}
+                            {% endfor %}
                         </div>
                     </div>
 
                     <div class="skills mt-3">
                         <h3 class="header-font"><span style="color: #b3e54c;">Ski</span>lls</h3>
                         <div class="content ml-5 header-font">
-                            Cadence - Virtuoso <br>
-                            Keysight - ADS <br>
-                            Layout of IC's <br>
-                            Matlab - Neural Networks <br>
-                            Languages: C, C++, VerilogA <br>
-                            Autocad <br>
-                            Office <br>
+                            {% for i in range(skill_names|length) %}
+                            {{skill_names[i]}} <br>
+                            {% endfor %}
                         </div>
                     </div>
 
                     <div class="activities-and-societies mt-3">
-                        <h3 class="header-font"><span style="color: #965efe;">Act</span>ivities and Societies</h3>
+                        <h3 class="header-font"><span style="color: #965efe;">Hon</span>ors and Awards</h3>
                         <div class="content ml-5 header-font">
-                            Teaching practice in Master's Degree (15 Hs) <br>
-                            Group of integrated circuits and systems (GICs) <br>
-                            Scientific Research in Bachelor's Degree <br>
+                            {% for i in range(honor_titles|length) %}
+                            {{honor_titles[i]}}, {{honor_issuers[i]}} ({{honor_issued_dates[i]}}) <br>
+                            {% endfor %}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This closes #57.

### Solution
I have cloned the given template (28) into HTML, complete with jinja2 templating.

### Screenshots
These are screenshots with hard-coded information (as provided in the pdf template).

![Screenshot (223)](https://user-images.githubusercontent.com/51695690/94795534-16418780-03fb-11eb-83ab-819ae14d7cec.png)
![Screenshot (224)](https://user-images.githubusercontent.com/51695690/94795545-18a3e180-03fb-11eb-914b-76396e35380c.png)

*Zoomed out view*
![Screenshot (225)](https://user-images.githubusercontent.com/51695690/94795568-25283a00-03fb-11eb-85d8-032d1909cb4b.png)

### Matters needing second opinion
- I have left the 'Languages' section with a single hardcoded field 'English - advanced', as the database schema does not have this field. 
- In the 'Research' section, I have placed the projects from the resume details, as I found that to be closest fitting. Is that fine, or could we change the title to 'Projects' instead?
- Since I could not find anything that really matched 'Activities and Societies' in the schema, I have replaced it with 'Honors and Awards' to display the awards from the resume details. (This is not reflected in the screenshots above)

Please let me know how we can proceed with regard to the above and about any other changes. @dhairyaj  @frankhart2018 